### PR TITLE
Update no-title-bar.less

### DIFF
--- a/styles/no-title-bar.less
+++ b/styles/no-title-bar.less
@@ -22,6 +22,15 @@
         .title-bar .title {
             display: none;
         }
+        
+
+        .tab-bar {
+            &::after {
+                content: '';
+                flex: 1 auto;
+                -webkit-app-region: drag;
+            }
+        }
 
         .title-bar,
         .tool-bar,


### PR DESCRIPTION
will let you drag window of empty space if you have compact/fixed size tabs