### PR TITLE
Removes broken cruft and adds updates for Atom 1.19.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,11 @@
 module.exports = {
-    "extends": "standard",
-    "installedESLint": true,
-    "plugins": [
-        "standard",
-        "promise"
-    ],
-    "globals": {
-      "atom": true,
-    },
-};
+  'extends': 'standard',
+  'installedESLint': true,
+  'plugins': [
+    'standard',
+    'promise'
+  ],
+  'globals': {
+    'atom': true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ os:
   - linux
   - osx
 
+dist: trusty
+
 ### Generic setup follows ###
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
@@ -36,8 +38,10 @@ sudo: false
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - build-essential
-    - git
-    - libgnome-keyring-dev
+    - g++-6
     - fakeroot
+    - git
+    - libsecret-1-dev

--- a/lib/no-title-bar.js
+++ b/lib/no-title-bar.js
@@ -1,111 +1,18 @@
 /** @babel */
 
-import {CompositeDisposable} from 'atom'
-
-var hasBeenActive = false
-var init = false
-var subs = null
-var tabBar = null
-var tabBarHeight = null
-
-function disableDrag () {
-  tabBar.querySelectorAll('.tab').forEach((tab) => {
-    tab.style.display = ''
-  })
-  tabBar.style.height = ''
-}
-
-function enableDrag () {
-  tabBar.querySelectorAll('.tab').forEach((tab) => {
-    tab.style.display = 'none'
-  })
-  tabBar.style.height = tabBarHeight
-}
-
-function toggleDrag (event) {
-  if (event.metaKey) {
-    enableDrag()
-  } else {
-    disableDrag()
-  }
-}
-
-function __guard__ (value, transform) {
-  return (typeof value !== 'undefined' && value !== null)
-    ? transform(value)
-    : undefined
-}
-
-function handleEvents () {
-  if (!atom.config.get('no-title-bar.metaKeyMouseDrag')) {
-    return
-  }
-
-  tabBar = document.querySelector('.tab-bar')
-  if (!init) {
-    tabBarHeight = window.getComputedStyle(tabBar).height
-    tabBar.addEventListener('mouseenter', toggleDrag)
-    tabBar.addEventListener('mousemove', toggleDrag)
-    tabBar.addEventListener('mouseleave', disableDrag)
-    init = true
-  }
-  hasBeenActive = true
-}
-
-function removeEvents () {
-  if (init) {
-    tabBar.removeEventListener('mouseenter', toggleDrag)
-    tabBar.removeEventListener('mousemove', toggleDrag)
-    tabBar.removeEventListener('mouseleave', disableDrag)
-    init = false
-  }
-}
-
 export function enabledForPlatform (platform) {
+  atom.getPosition()
   return document.body.classList.contains(`platform-${platform}`)
 }
 
 export function activate (state) {
-  if (!enabledForPlatform(process.platform)) {
-    return
-  }
-
-  subs = new CompositeDisposable()
-  subs.add(atom.themes.onDidChangeActiveThemes(handleEvents))
-  subs.add(atom.config.observe('no-title-bar.metaKeyMouseDrag', (value) => {
-    if (value) {
-      if (hasBeenActive) {
-        handleEvents()
-      }
-    } else {
-      removeEvents()
-    }
-  }))
-
-  document.body.classList.add('no-title-bar')
-
-  if (hasBeenActive && atom.config.get('no-title-bar.metaKeyMouseDrag')) {
-    handleEvents() // package has been re-activated
+  if (enabledForPlatform(process.platform)) {
+    document.body.classList.add('no-title-bar')
   }
 }
 
 export function deactivate () {
-  if (!enabledForPlatform(process.platform)) {
-    return
-  }
-
-  __guard__(subs, x1 => x1.dispose())
-  subs = null
-
-  removeEvents()
-
-  document.body.classList.remove('no-title-bar')
-}
-
-export const config = {
-  'metaKeyMouseDrag': {
-    'title': 'Use ⌘ + Mouse on the Tab Bar to drag the Atom window.',
-    'type': 'boolean',
-    'default': false
+  if (enabledForPlatform(process.platform)) {
+    document.body.classList.remove('no-title-bar')
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "repository": "https://github.com/lexicalunit/no-title-bar",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.16.0 <2.0.0"
+    "atom": ">=1.19.0 <2.0.0"
   },
   "dependencies": {},
   "devDependencies": {

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "env": {
-    "jasmine": true,
-    "atomtest": true
-  }
-}

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  'env': {
+    'jasmine': true,
+    'atomtest': true
+  }
+}

--- a/styles/no-title-bar.less
+++ b/styles/no-title-bar.less
@@ -1,93 +1,94 @@
 @import "ui-variables";
 
 #atom-no-title-bar() {
-    // This width seems to work well for many themes, but may not be
-    // ideal for all themes. A more universal solution is desired.
-    @title-bar-buttons-width: 80px;
+  // This width seems to work well for many themes, but may not be
+  // ideal for all themes. A more universal solution is desired.
+  @title-bar-buttons-width: 80px;
 
-    // Ensure vertical offsets so that title bar is hidden and panels
-    // such as the tree-view, for example, are properly adjusted.
-    .ensure-vertical-offsets() {
-        atom-workspace-axis.horizontal {
-            // Hide the title bar itself.
-            margin-top: -@title-bar-height;
+  // Ensure vertical offsets so that title bar is hidden and panels
+  // such as the tree-view, for example, are properly adjusted.
+  .ensure-vertical-offsets() {
+    atom-workspace-axis.horizontal {
+      // Hide the title bar itself.
+      margin-top: -@title-bar-height;
 
-            // Vertical offset space of panels should blend with inactive tabs.
-            background-color: @tab-bar-background-color;
-        }
-
-        // The units given to max() must match. I've seen themes use px and rem
-        // before, so those two cases are defined here. If there are other
-        // themes out there that use different units, they must be added.
-        atom-panel-container when (ispixel(@tab-height)) {
-          @panel-margin-top: max(@title-bar-height, @tab-height);
-          &.left { margin-top: @panel-margin-top; }
-          &.right { margin-top: @panel-margin-top; }
-        }
-
-        atom-panel-container when (isunit(@tab-height, rem)) {
-          @tile-bar-height-rem: unit(unit(@title-bar-height) / unit(@font-size), rem);
-          @panel-margin-top: max(@tile-bar-height-rem, @tab-height);
-          &.left { margin-top: @panel-margin-top; }
-          &.right { margin-top:@panel-margin-top; }
-        }
+      // Vertical offset space of panels should blend with inactive tabs.
+      background-color: @tab-bar-background-color;
     }
 
-    // Vertical offsets will vary slightly by title bar setting.
-    .no-title-bar:not(.fullscreen).custom-title-bar > atom-workspace {
-        @title-bar-height: 22px;
-        .ensure-vertical-offsets();
-    }
-    .no-title-bar:not(.fullscreen).custom-inset-title-bar > atom-workspace {
-        @title-bar-height: 38px;
-        .ensure-vertical-offsets();
-    }
-
-    // In any case, the title label of the title bar will not be seen.
-    atom-workspace {
-        .title-bar .title {
-            display: none;
-        }
+    // The units given to max() must match. I've seen themes use px and rem
+    // before, so those two cases are defined here. If there are other
+    // themes out there that use different units, they must be added.
+    atom-panel-container when (ispixel(@tab-height)) {
+      @panel-margin-top: max(@title-bar-height, @tab-height);
+      &.left { margin-top: @panel-margin-top; }
+      &.right { margin-top: @panel-margin-top; }
     }
 
-    // Ensure horizontal padding for the macOS window buttons. Note that these
-    // buttons are gone when using the hidden title bar mode.
-    .platform-darwin.no-title-bar:not(.fullscreen):not(.hidden-title-bar)
-        atom-panel-container.left:empty + atom-workspace-axis.vertical
-                                          .pane:nth-child(1)
-                                          .tab-bar
+    atom-panel-container when (isunit(@tab-height, rem)) {
+      @tile-bar-height-rem: unit(unit(@title-bar-height) / unit(@font-size), rem);
+      @panel-margin-top: max(@tile-bar-height-rem, @tab-height);
+      &.left { margin-top: @panel-margin-top; }
+      &.right { margin-top:@panel-margin-top; }
+    }
+  }
+
+  // Vertical offsets will vary slightly by title bar setting.
+  .no-title-bar:not(.fullscreen).custom-title-bar > atom-workspace {
+    @title-bar-height: 22px;
+    .ensure-vertical-offsets();
+  }
+  .no-title-bar:not(.fullscreen).custom-inset-title-bar > atom-workspace {
+    @title-bar-height: 38px;
+    .ensure-vertical-offsets();
+  }
+
+  // In any case, the title label of the title bar will not be seen.
+  atom-workspace {
+    .title-bar .title {
+      display: none;
+    }
+  }
+
+  // Ensure horizontal padding for the macOS window buttons. Note that these
+  // buttons are gone when using the hidden title bar mode.
+  .platform-darwin.no-title-bar:not(.fullscreen):not(.hidden-title-bar)
+    atom-panel-container.left:empty + atom-workspace-axis.vertical
+                      .pane:nth-child(1)
+                      .tab-bar
+  {
+    padding-left: @title-bar-buttons-width;
+  }
+
+  .no-title-bar:not(.fullscreen) > atom-workspace {
+    // Enable blanket window drag on every element in Atom.
+    -webkit-app-region: drag;
+
+    // Then specifically disable it where we do NOT want drag.
+    .atom-dock-resize-handle,
+    .editor,
+    .key-binding-resolver,      // don't interfere with keybinding resolver
+    .linter,                    // copy/paste in linter v2 table
+    .settings-view,             // copy/paste in settings pane text
+    .tab-bar .tab,              // reordering of tabs
+    .tree-view .entry,          // reordering of tree-view items
+    .tree-view-resize-handle,
+    atom-pane-resize-handle,
+    atom-pane-resize-handle.horizontal:before,
+    atom-pane-resize-handle.vertical:before,
+    linter-message .linter-message-item,    // copy/paste linter v1
+    linter-message .linter-message-link     // copy/paste linter v1
     {
-        padding-left: @title-bar-buttons-width;
+      -webkit-app-region: no-drag;
     }
 
-    .no-title-bar:not(.fullscreen) > atom-workspace {
-        // Enable blanket window drag on every element in Atom.
-        -webkit-app-region: drag;
-
-        // Then specifically disable it where we do NOT want drag.
-        .atom-dock-resize-handle,
-        .editor,
-        .linter,                    // copy/paste in linter v2 table
-        .settings-view,             // copy/paste in settings pane text
-        .tab-bar .tab,              // reordering of tabs
-        .tree-view .entry,          // reordering of tree-view items
-        .tree-view-resize-handle,
-        atom-pane-resize-handle,
-        atom-pane-resize-handle.horizontal:before,
-        atom-pane-resize-handle.vertical:before,
-        linter-message .linter-message-item,    // copy/paste linter v1
-        linter-message .linter-message-link     // copy/paste linter v1
-        {
-            -webkit-app-region: no-drag;
-        }
-
-        // This may be unnecessary...
-        .title-bar,
-        .tool-bar,
-        .tool-bar button.tool-bar-btn {
-            border-width: 0;
-        }
+    // This may be unnecessary...
+    .title-bar,
+    .tool-bar,
+    .tool-bar button.tool-bar-btn {
+      border-width: 0;
     }
+  }
 }
 
 #atom-no-title-bar;


### PR DESCRIPTION
Metakey event stuff doesn't seem to work in the new versions of Atom.